### PR TITLE
fix: remove "products" from homepage titles

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -23,9 +23,9 @@
   {% paginate products from products.current by theme.featured_products order:theme.featured_order %}
     {% case theme.featured_order %}
     	{% when 'date' %}
-    		{% assign featured_title = 'Newest Items' %}
+    		{% assign featured_title = 'Newest' %}
     	{% when 'position' %}
-    		{% assign featured_title = 'Featured Items' %}
+    		{% assign featured_title = 'Featured' %}
     	{% when 'sells' %}
     		{% assign featured_title = 'Best Sellers' %}
       {% when 'views' %}


### PR DESCRIPTION
Simplify the title on homepage to just "Featured", "Newest"  and drop the "items" suffix