### PR TITLE
fix: Homepage heading not using corrected `featured_order` values

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -22,11 +22,11 @@
 {% if theme.featured_products > 0 %}
   {% paginate products from products.current by theme.featured_products order:theme.featured_order %}
     {% case theme.featured_order %}
-    	{% when 'date' %}
+    	{% when 'newest' %}
     		{% assign featured_title = 'Newest' %}
-    	{% when 'position' %}
+    	{% when 'regular' %}
     		{% assign featured_title = 'Featured' %}
-    	{% when 'sells' %}
+    	{% when 'top-selling' %}
     		{% assign featured_title = 'Best Sellers' %}
       {% when 'views' %}
         {% assign featured_title = 'Most Popular' %}


### PR DESCRIPTION
Homepage heading is not using the correct values for featured_order setting.  So when you set it to say "Newest", no title is shown.